### PR TITLE
update org.activiti.cloud.dependencies:activiti-cloud-dependencies to 7.1.106

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <serenity-jbehave.version>1.44.0</serenity-jbehave.version>
     <awaitility.version>3.1.1</awaitility.version>
     <batik.version>1.10</batik.version>
-    <activiti-cloud-dependencies.version>7.1.105</activiti-cloud-dependencies.version>
+    <activiti-cloud-dependencies.version>7.1.106</activiti-cloud-dependencies.version>
     <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
     <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.cloud.dependencies:activiti-cloud-dependencies` to: `7.1.106`